### PR TITLE
fix fromJSON example code

### DIFF
--- a/rjson/man/fromJSON.Rd
+++ b/rjson/man/fromJSON.Rd
@@ -30,7 +30,7 @@ fromJSON('[1,2,3]', simplify=FALSE)
 #As a result, this will output "1"
 toJSON(fromJSON('[1]', simplify=TRUE))
 #Compared with this which will output "[1]" as expected
-toJSON(fromJSON('[1]', simplify=TRUE))
+toJSON(fromJSON('[1]', simplify=FALSE))
 
 #R vs C execution time
 x <- toJSON( iris )


### PR DESCRIPTION
This fixes an error in the docstring in the example section of the `fromJSON` function.