### PR TITLE
Extra-BMP Unicode Support

### DIFF
--- a/rjson/inst/unittests/test.unicode.r
+++ b/rjson/inst/unittests/test.unicode.r
@@ -33,6 +33,10 @@ test.unicode <- function()
 	checkTrue( all( charToRaw( x ) == c( 0xe3, 0x80, 0xa0 ) ) )
 	checkTrue( length( charToRaw( x ) ) == 3 )
 
+	#test 4 byte utf8 unicode roundtrip
+	emo <- "\U1F600"
+	checkIdentical(fromJSON(toJSON(emo)), emo)
+
 	#x = newJSONParser()
 	#x$addData( "\"\\u00" )
 	#checkTrue( is.null( x$getObject() ) ) #should be incomplete

--- a/rjson/src/dump.cpp
+++ b/rjson/src/dump.cpp
@@ -54,10 +54,10 @@ std::string escapeString( const char *s )
 					s += 2;
 				} else if( (ch & 0xF8) == 0xF0 && s[1] && s[2] && s[3] ) {
 					// 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
-					unsigned int val = (s[3] & 0x3F) + ((s[2] & 0x3F) << 6) + ((s[1] & 0x3F) << 12) + ((s[0] & 0x07) << 18);
+					unsigned long val = (s[3] & 0x3F) + ((s[2] & 0x3F) << 6) + ((s[1] & 0x3F) << 12) + ((s[0] & 0x07) << 18);
 					// Per JSON spec, encode as UTF-16 https://en.wikipedia.org/wiki/UTF-16#Code_points_from_U+010000_to_U+10FFFF
 					// Could probably do directly from UTF-8 for improved performance
-					unsigned int U = val - 0x10000;
+					unsigned long U = val - 0x10000;
 					unsigned short hi = (U >> 10) + 0xD800;
 					unsigned short lo = (U & 0x3FF) + 0xDC00;
 					oss << "\\u" << std::setfill('0') << std::setw(4) << std::hex << hi << std::dec;

--- a/rjson/src/dump.cpp
+++ b/rjson/src/dump.cpp
@@ -52,6 +52,17 @@ std::string escapeString( const char *s )
 					unsigned short val = (s[2] & 0x3F) + ((s[1] & 0x3F) << 6) + ((s[0] & 0x0F) << 12);
 					oss << "\\u" << std::setfill('0') << std::setw(4) << std::hex << val << std::dec;
 					s += 2;
+				} else if( (ch & 0xF8) == 0xF0 && s[1] && s[2] && s[3] ) {
+					// 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+					unsigned int val = (s[3] & 0x3F) + ((s[2] & 0x3F) << 6) + ((s[1] & 0x3F) << 12) + ((s[0] & 0x07) << 18);
+					// Per JSON spec, encode as UTF-16 https://en.wikipedia.org/wiki/UTF-16#Code_points_from_U+010000_to_U+10FFFF
+					// Could probably do directly from UTF-8 for improved performance
+					unsigned int U = val - 0x10000;
+					unsigned short hi = (U >> 10) + 0xD800;
+					unsigned short lo = (U & 0x3FF) + 0xDC00;
+					oss << "\\u" << std::setfill('0') << std::setw(4) << std::hex << hi << std::dec;
+					oss << "\\u" << std::setfill('0') << std::setw(4) << std::hex << lo << std::dec;
+					s += 3;
 				} else {
 					error("unable to escape string. String is not utf8\n");
 				}


### PR DESCRIPTION
Adds support for escaping Extra-BMP Unicode using UTF-16 surrogate pairs.

Note I have very limited familiarity with C++ (I'm a C person) so I just copy pasted existing code and adapted in a way that appears to work, so please review carefully.

Related question: Is the escaping actually necessary?  It appears optional based on the JSON RFC and `{jsonlite}` does not appear to bother with it.